### PR TITLE
MOB-745 Adding Lithium User Agent instead of default user agent

### DIFF
--- a/lia-core/src/main/java/com/lithium/community/android/auth/LiLoginActivity.java
+++ b/lia-core/src/main/java/com/lithium/community/android/auth/LiLoginActivity.java
@@ -117,7 +117,7 @@ public class LiLoginActivity extends LiBaseAuthActivity {
                 webSettings.setJavaScriptEnabled(true);
                 webSettings.setCacheMode(WebSettings.LOAD_NO_CACHE);
                 webSettings.setAppCacheEnabled(false);
-                webSettings.setUserAgentString("Lithium-User:".concat(System.getProperty("http.agent")));
+                webSettings.setUserAgentString(String.format("%s : %s", getString(R.string.app_name), System.getProperty("http.agent")));
 
                 //load the url of the oAuth login page
                 webViewOauth.loadUrl(url);

--- a/lia-core/src/main/java/com/lithium/community/android/auth/LiLoginActivity.java
+++ b/lia-core/src/main/java/com/lithium/community/android/auth/LiLoginActivity.java
@@ -117,6 +117,7 @@ public class LiLoginActivity extends LiBaseAuthActivity {
                 webSettings.setJavaScriptEnabled(true);
                 webSettings.setCacheMode(WebSettings.LOAD_NO_CACHE);
                 webSettings.setAppCacheEnabled(false);
+                webSettings.setUserAgentString("Lithium-User:".concat(System.getProperty("http.agent")));
 
                 //load the url of the oAuth login page
                 webViewOauth.loadUrl(url);


### PR DESCRIPTION
Default user-agent was blocked for Webview Google authentication, hence prepending "Lithium User:" to the default User-agent to make it Lithium-User-agent.